### PR TITLE
added callback for renderer size

### DIFF
--- a/threex.windowresize.js
+++ b/threex.windowresize.js
@@ -22,13 +22,17 @@ var THREEx	= THREEx || {}
  * 
  * @param {Object} renderer the renderer to update
  * @param {Object} Camera the camera to update
+ * @param {Function} dimension callback for renderer size
 */
-THREEx.WindowResize	= function(renderer, camera){
+THREEx.WindowResize	= function(renderer, camera, dimension){
+	dimension 	= dimension || function(){ return { width: window.innerWidth, height: window.innerHeight } }
 	var callback	= function(){
+		// fetch target renderer size
+		var rendererSize = dimension();
 		// notify the renderer of the size change
-		renderer.setSize( window.innerWidth, window.innerHeight )
+		renderer.setSize( rendererSize.width, rendererSize.height )
 		// update the camera
-		camera.aspect	= window.innerWidth / window.innerHeight
+		camera.aspect	= rendererSize.width / rendererSize.height
 		camera.updateProjectionMatrix()
 	}
 	// bind the resize event


### PR DESCRIPTION
window.innerWidth and window.innerHeight are only useful, if the canvas
is actually filling the whole screen. This is not always the case. E.g.
the game has a sidebar for ads, an user interface written in html/css at
the bottom, a navigation bar at the top, etc.

Example: The game has a chat at the bottom with a height of 200px, the
new code would look like this:

``` javascript
var windowResize = new THREEx.WindowResize(aRenderer, aCamera, function(){ 
    return { width: window.innerWidth, height: window.innerHeight - 200 } 
})
```

The dimension callback is optional and can also be used to execute other functions on
window resize without manually adding another event listener.
