### PR TITLE
added set of options

### DIFF
--- a/threex.windowresize.js
+++ b/threex.windowresize.js
@@ -22,24 +22,76 @@ var THREEx	= THREEx || {}
  * 
  * @param {Object} renderer the renderer to update
  * @param {Object} Camera the camera to update
- * @param {Function} dimension callback for renderer size
+ * @param {Object} opts various settings for the window resizer
 */
-THREEx.WindowResize	= function(renderer, camera, dimension){
-	dimension 	= dimension || function(){ return { width: window.innerWidth, height: window.innerHeight } }
-	var callback	= function(){
-		// fetch target renderer size
-		var rendererSize = dimension();
+THREEx.WindowResize	= function(renderer, camera, opts){
+
+	opts		= opts		|| {}
+	opts.width	= opts.width	|| function(){ return window.innerWidth }	// {Function} width getter
+	opts.height	= opts.height	|| function(){ return window.innerHeight }	// {Function} height getter
+	opts.maxWidth	= opts.maxWidth	|| null						// {Number} limit the width of the renderer
+	opts.maxHeight	= opts.maxHeight|| null						// {Number} limit the height of the renderer
+	opts.before	= opts.before	|| null						// {Function} callback before resize happened
+	opts.after	= opts.after	|| null						// {Function} callback after resize happened
+	opts.scale	= opts.scale	|| 'default'					// {String} 3d || 2d || default
+
+	// get css prefix (only needed for scale 3d/2d
+	var prefix = (function (name) {
+		var style = window.getComputedStyle(document.documentElement, '')
+		var cssPrefixes = ["Webkit", "O", "Moz", "ms"]
+		if (!(name in style)) {
+			var capName = name.charAt(0).toUpperCase() + name.slice(1)
+			for(var i = 0; i < cssPrefixes.length; i++) {
+				if ((cssPrefixes[i] + capName) in style) {
+					return '-' + cssPrefixes[i].toLowerCase() + '-'
+				}
+			}
+		}
+		return ''
+	})('transform');
+
+	// resize callback
+	var callback = function(){
+		if(opts.before) opts.before()
+
+		var width	= opts.width()
+		var height	= opts.height()
+		var maxWidth	= opts.maxWidth && opts.maxWidth < width ? opts.maxWidth : width
+		var maxHeight	= opts.maxHeight && opts.maxHeight < height ? opts.maxHeight : height
+		
 		// notify the renderer of the size change
-		renderer.setSize( rendererSize.width, rendererSize.height )
+		renderer.setSize( maxWidth, maxHeight, false )
+
+		// scale to window size
+		renderer.domElement.style.cssText = ''
+		if(opts.scale === '3d') {
+			renderer.domElement.style[prefix + 'transform'] = 'scale3d(' + width/maxWidth + ',' + height/maxHeight + ',1)'
+			renderer.domElement.style[prefix + 'transform-origin'] = 'left top'
+		} else if(opts.scale === '2d') {
+			renderer.domElement.style[prefix + 'transform'] = 'scale(' + width/maxWidth + ',' + height/maxHeight + ')'
+			renderer.domElement.style[prefix + 'transform-origin'] = 'left top'
+		} else if(opts.scale === 'default') {
+			renderer.domElement.style.width	 = width + 'px'
+			renderer.domElement.style.height = height + 'px'
+		}
+
 		// update the camera
-		camera.aspect	= rendererSize.width / rendererSize.height
+		camera.aspect  = width / height
 		camera.updateProjectionMatrix()
+
+		if(opts.done) opts.done()
 	}
+
 	// bind the resize event
 	window.addEventListener('resize', callback, false)
+
 	// return .stop() the function to stop watching window resize
 	return {
 		trigger	: function(){
+			callback()
+		},
+		option	: function(key, value){
+			opts[key] = value
 			callback()
 		},
 		/**


### PR DESCRIPTION
Alright, let's see the changes.

The third parameter of THREEx.WindowResize has been changed to an
options object.

The options object has a width and height getter, aswell as several
scaling options. Imagine someone loading your game on a widescreen tv.
How many fps will he get?

Now you can define a maxWidth and maxHeight property + a scaling method
(3d transform, 2d transform, width/height scale, no scale) and the
window resizer will scale the renderer for you. This most likely can be
improved later on.

Another change is the before and the after callback. Sometimes you want
to do something after or before the renderer is resized. This will allow
you to keep all your resize handlers perfectly organized.

To change a setting on the fly, you can simply say

``` javascript
var windowResize = new THREEx.WindowResize(renderer, camera);
windowResize.option("maxWidth", 1234);
```

This can be useful for ingame settings where players can decide to make
their viewport smaller to increase their fps and gaming experience.

Opinions?

``` javascript
    var windowResize = new THREEx.WindowResize(renderer, camera, {
        width     : function() { return $(window).innerWidth(); },
        height    : function() { return $(window).innerHeight() - 200; },
        maxWidth  : 1024,
        maxHeight : 756,
        after     : otherResizeHandlers,
        scale     : '3d'
    });
    windowResize.trigger();
```

This is just a proposal. Should be discussed though!
